### PR TITLE
Always use cache when loading entry URL

### DIFF
--- a/build.worker.ts
+++ b/build.worker.ts
@@ -20,7 +20,7 @@ self.addEventListener<"message">("message", async (event) => {
     await initialized;
     const { entryURL, reload, importmap, ...options } =
       (event.data) as BundleOptions;
-    const { response } = await fetch(entryURL);
+    const { response } = await fetch(entryURL, reload);
     const loader = getLoader(response);
 
     const importMap = importmap


### PR DESCRIPTION
see [entry pointのURLをreloadで再読み込みで来ていない](https://scrapbox.io/takker/entry_point%E3%81%AEURL%E3%82%92reload%E3%81%A7%E5%86%8D%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF%E3%81%A7%E6%9D%A5%E3%81%A6%E3%81%84%E3%81%AA%E3%81%84)