### PR TITLE
Enable to fetch some cross-origin urls

### DIFF
--- a/fetch.ts
+++ b/fetch.ts
@@ -1,16 +1,16 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
+import { proxy as switcher } from "./proxy.ts";
 
 let cache: Cache | undefined;
 
-export async function fetch(path: URL | string, reload = false) {
-  const url = new URL(path);
-  if (url.hostname === "scrapbox.io") {
-    url.port = "";
-    url.protocol = "https:";
-    url.hostname = "scrapbox-proxy-server.vercel.app";
-  }
+export async function fetch(
+  path: URL | string,
+  reload = false,
+  proxy = switcher,
+) {
+  const url = await proxy(new URL(path));
   cache ??= await globalThis.caches.open("v1");
   if (reload) {
     return await fetchNetworkFirst(url);

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,20 @@
+import { proxy as proxyPaxDeno } from "./proxy/pax.deno.dev.ts";
+import { proxy as proxyDenoLand } from "./proxy/deno.land.ts";
+
+export function proxy(url: URL): Promise<URL> {
+  switch (url.hostname) {
+    case "scrapbox.io": {
+      const newURL = new URL(url);
+      newURL.port = "";
+      newURL.protocol = "https:";
+      newURL.hostname = "scrapbox-proxy-server.vercel.app";
+      return Promise.resolve(newURL);
+    }
+    case "pax.deno.dev":
+      return Promise.resolve(proxyPaxDeno(url.pathname));
+    case "deno.land":
+      return proxyDenoLand(url.pathname);
+    default:
+      return Promise.resolve(url);
+  }
+}

--- a/proxy/deno.land.ts
+++ b/proxy/deno.land.ts
@@ -1,0 +1,53 @@
+const hostname = "deno.land";
+export async function proxy(pathname: string): Promise<URL> {
+  {
+    const match = pathname.match(
+      /^\/x\/([^\/@]+)(@[^\/]+)?(\/.*)?/,
+    );
+    if (match) {
+      const name = match[1];
+      const version = match[2]?.slice?.(1);
+      const file = match[3] ?? "";
+      return await resolve("x", name, version, file);
+    }
+  }
+  const match = pathname.match(
+    /^\/std(@[^\/]+)?\/([^\/@]+)(\/.*)?/,
+  );
+  if (!match) throw URIError(`"${pathname}" is an invalid deno.land pathname`);
+  const name = match[2];
+  const version = match[1]?.slice?.(1);
+  const file = match[3] ?? "";
+  return await resolve("std", name, version, file);
+}
+
+async function resolve(
+  type: Package,
+  name: string,
+  version: string | undefined,
+  file: string,
+): Promise<URL> {
+  if (version !== undefined) {
+    return new URL(
+      `https://${hostname}/${
+        type === "x" ? `x/${name}@${version}` : `std@${version}/${name}`
+      }${file}`,
+    );
+  }
+
+  const res = await fetch(
+    `https://cdn.deno.land/${type === "x" ? name : "std"}/meta/versions.json`,
+  );
+  if (!res.ok) {
+    throw { status: res.status, statusText: res.statusText };
+  }
+  const { latest } = (await res.json()) as Versions;
+  return await resolve(type, name, latest, file);
+}
+
+interface Versions {
+  latest: string;
+  versions: string[];
+}
+
+type Package = "x" | "std";

--- a/proxy/pax.deno.dev.ts
+++ b/proxy/pax.deno.dev.ts
@@ -1,0 +1,25 @@
+// The following code is based on https://github.com/kawarimidoll/pax.deno.dev/raw/d1dcae1fcbe0a5f77c89b028ddfae92daf8df92a/utils.ts
+function extract(path: string) {
+  const match = path.match(/^\/([^\/]+)\/([^\/@]+)(@[^\/]+)?(\/.*)?/);
+  if (!match) return [];
+
+  const [, owner, repo, atTag, file] = match;
+  return [
+    owner,
+    repo,
+    atTag ? atTag.slice(1) : "master",
+    file?.replace(/^\/|\/$/g, "") || "mod.ts",
+  ];
+}
+
+export function proxy(pathname: string): URL {
+  const [owner, repo, tag, file] = extract(pathname);
+
+  if (!owner || !repo) {
+    throw URIError("invalid pax.deno.dev URL");
+  }
+
+  const host = "https://raw.githubusercontent.com";
+  const location = [host, owner, repo, tag, file].join("/");
+  return new URL(location);
+}


### PR DESCRIPTION

## Proposal changes

一部のdomainからCORSを回避してソースコードを取得できるようにした

対応したdomain
- deno.land
- pax.deno.dev
- scrapbox.io (以前から対応済み)

see [scrapbox-bundlerにおけるCORS制限つきコードの取得方法](https://scrapbox.io/takker/scrapbox-bundlerにおけるCORS制限つきコードの取得方法)

## issue

まだテストは書いていない