### PR TITLE
Add `output` parameter

### DIFF
--- a/build.worker.ts
+++ b/build.worker.ts
@@ -54,8 +54,25 @@ self.addEventListener<"message">("message", async (event) => {
         }),
       ],
     });
+
+    let extension: "js" | "css" | "txt";
+    switch (loader) {
+      case "js":
+      case "jsx":
+      case "ts":
+      case "tsx":
+        extension = "js";
+        break;
+      case "css":
+        extension = "css";
+        break;
+      default:
+        extension = "txt";
+        break;
+    }
     postMessage({
       type: "built",
+      extension,
       code: result.outputFiles[0].contents,
     });
   } catch (e) {

--- a/parseParams.ts
+++ b/parseParams.ts
@@ -2,6 +2,7 @@ import { BundleOptions, isFormat } from "./types.ts";
 
 export type ParamOptions = BundleOptions & {
   run: boolean;
+  output: "self" | "newtab" | "download";
 };
 
 export function parseSearchParams(searchParam: string): ParamOptions {
@@ -12,6 +13,7 @@ export function parseSearchParams(searchParam: string): ParamOptions {
   const format = params.get("format") ?? "esm";
   const charset = params.get("noUtf8") === null ? "utf8" : undefined;
   const run = params.get("run") === null ? false : true;
+  const output = params.get("output") ?? "self";
   const jsxFactory = params.get("jsxFactory") ?? "h";
   const jsxFragment = params.get("jsxFragment") ?? "Fragment";
   const entryURL = params.get("url") ?? "";
@@ -28,10 +30,15 @@ export function parseSearchParams(searchParam: string): ParamOptions {
     entryURL,
     external,
     run,
+    output: isOutput(output) ? output : "self",
     jsxFactory,
     jsxFragment,
     reload,
     sourcemap,
     importMapURL,
   };
+}
+
+function isOutput(output: string): output is "self" | "newtab" | "download" {
+  return ["self", "newtab", "download"].includes(output);
 }

--- a/types.ts
+++ b/types.ts
@@ -24,6 +24,7 @@ export type SkipInfo = {
 };
 export type BuiltInfo = {
   type: "built";
+  extension: "js" | "css" | "txt";
   code: Uint8Array;
 };
 export type BuildErrorInfo = {


### PR DESCRIPTION
Support the following outputs
- `self`(default): open built code at the same tab
- `newtab`: open built code at a new tab
- `download`: download built code 

For more information, see [🔳生成したコードの取得方法を増やす (scrapbox-bundler)](https://scrapbox.io/takker/🔳生成したコードの取得方法を増やす_(scrapbox-bundler)) 