### PR TITLE
Enable to use an esbuild option `define`

### DIFF
--- a/parseParams.test.ts
+++ b/parseParams.test.ts
@@ -12,16 +12,26 @@ Deno.test("parseDefine", () => {
     parseDefine([
       "magic_number:3443",
       "AUTH_TOKEN:ser43e8fh",
+      "URL:https://example.com",
     ]),
-    { magic_number: "3443", AUTH_TOKEN: "ser43e8fh" },
+    {
+      magic_number: "3443",
+      AUTH_TOKEN: "ser43e8fh",
+      URL: "https://example.com",
+    },
   );
   assertEquals(
     parseDefine([
       "invalid string",
       "magic_number:3443",
       "AUTH_TOKEN:ser43e8fh",
+      "URL:https://example.com",
     ]),
-    { magic_number: "3443", AUTH_TOKEN: "ser43e8fh" },
+    {
+      magic_number: "3443",
+      AUTH_TOKEN: "ser43e8fh",
+      URL: "https://example.com",
+    },
   );
 });
 Deno.test("parseDefine: the same keys are overwritten", () => {

--- a/parseParams.test.ts
+++ b/parseParams.test.ts
@@ -1,0 +1,31 @@
+import { parseDefine } from "./parseParams.ts";
+import { assertEquals } from "./deps/testing.ts";
+
+Deno.test("parseDefine", () => {
+  assertEquals(parseDefine([]), {});
+  assertEquals(parseDefine(["invalid string"]), {});
+  assertEquals(parseDefine(["magic_number:3443"]), { magic_number: "3443" });
+  assertEquals(parseDefine(["invalid string", "magic_number:3443"]), {
+    magic_number: "3443",
+  });
+  assertEquals(
+    parseDefine([
+      "magic_number:3443",
+      "AUTH_TOKEN:ser43e8fh",
+    ]),
+    { magic_number: "3443", AUTH_TOKEN: "ser43e8fh" },
+  );
+  assertEquals(
+    parseDefine([
+      "invalid string",
+      "magic_number:3443",
+      "AUTH_TOKEN:ser43e8fh",
+    ]),
+    { magic_number: "3443", AUTH_TOKEN: "ser43e8fh" },
+  );
+});
+Deno.test("parseDefine: the same keys are overwritten", () => {
+  assertEquals(parseDefine(["magic_number:3443", "magic_number:5464"]), {
+    magic_number: "5464",
+  });
+});

--- a/parseParams.ts
+++ b/parseParams.ts
@@ -12,6 +12,7 @@ export function parseSearchParams(searchParam: string): ParamOptions {
   const bundle = params.get("bundle") === null ? false : true;
   const minify = params.get("minify") === null ? false : true;
   const format = params.get("format") ?? "esm";
+  const define = parseDefine(params.getAll("define"));
   const charset = params.get("noUtf8") === null ? "utf8" : undefined;
   const run = params.get("run") === null ? false : true;
   const output = params.get("output") ?? "self";
@@ -31,6 +32,7 @@ export function parseSearchParams(searchParam: string): ParamOptions {
     charset,
     entryURL,
     external,
+    define,
     run,
     output: isOutput(output) ? output : "self",
     jsxFactory,
@@ -44,4 +46,14 @@ export function parseSearchParams(searchParam: string): ParamOptions {
 
 function isOutput(output: string): output is "self" | "newtab" | "download" {
   return ["self", "newtab", "download"].includes(output);
+}
+export function parseDefine(define: string[]) {
+  const defines = {} as Record<string, string>;
+  for (const pair of define) {
+    if (!pair.includes(":")) continue;
+    // the same keys are overwritten
+    const [key, value] = pair.split(":");
+    defines[key] = value;
+  }
+  return defines;
 }

--- a/parseParams.ts
+++ b/parseParams.ts
@@ -50,9 +50,11 @@ function isOutput(output: string): output is "self" | "newtab" | "download" {
 export function parseDefine(define: string[]) {
   const defines = {} as Record<string, string>;
   for (const pair of define) {
-    if (!pair.includes(":")) continue;
+    const pos = pair.indexOf(":");
+    if (pos < 0) continue;
     // the same keys are overwritten
-    const [key, value] = pair.split(":");
+    const key = pair.slice(0, pos);
+    const value = pair.slice(pos + 1);
     defines[key] = value;
   }
   return defines;

--- a/types.ts
+++ b/types.ts
@@ -55,6 +55,7 @@ export type BundleOptions = {
   format: Format;
   entryURL: string;
   external: string[];
+  define: Record<string, string>;
   jsxFactory: string;
   jsxFragment: string;
   reload: boolean;


### PR DESCRIPTION
ref [🔳esbuildのoption対応 (scrapbox-bundler)](https://scrapbox.io/takker/🔳esbuildのoption対応_(scrapbox-bundler))