### PR TITLE
fix: Reset old caches including old versions of `esbuild.wasm`, when starting to use the newer `esbuild`

### DIFF
--- a/fetch.ts
+++ b/fetch.ts
@@ -1,7 +1,18 @@
 import { createOk, isErr, unwrapOk } from "option-t/plain_result";
 import { RobustFetch, robustFetch } from "./deps/remoteLoader.ts";
+import { version } from "./deps/esbuild-wasm.ts";
 
-const cache = await globalThis.caches.open("v1");
+// Clear caches when the version changes
+for (const name of await globalThis.caches.keys()) {
+  if (name !== version) {
+    const cache = await globalThis.caches.open(name);
+    for (const req of await cache.keys()) {
+      await cache.delete(req);
+    }
+  }
+}
+const cache = await globalThis.caches.open(version);
+
 export const fetch: RobustFetch = async (req, cacheFirst) => {
   const request = proxy(req);
   if (cacheFirst) {


### PR DESCRIPTION
古い`esbuild.wasm`を消さないと、versionの食い違いで動かなくなってしまう